### PR TITLE
Changed log dir from home to cache

### DIFF
--- a/octasine/src/lib.rs
+++ b/octasine/src/lib.rs
@@ -428,9 +428,9 @@ cfg_if::cfg_if! {
 }
 
 fn init_logging() -> anyhow::Result<()> {
-    let log_folder = dirs::home_dir()
-        .ok_or(anyhow::anyhow!("Couldn't extract home dir"))?
-        .join("tmp");
+    let log_folder = dirs::cache_dir()
+        .ok_or(anyhow::anyhow!("Couldn't extract cache dir"))?
+        .join("octasine");
 
     // Ignore any creation error
     let _ = ::std::fs::create_dir(log_folder.clone());


### PR DESCRIPTION
Hello! I've noticed that OctaSine creates a log folder in the home folder, and I don't think that is a good place for it.
Most operating systems have an app cache / data dir, and we can get that through [`dirs::cache_dir()`](https://docs.rs/dirs/latest/dirs/fn.cache_dir.html).
I've tested it in my linux system (`Linux 5.16.11-arch1-1 x86_64 GNU/Linux`) and it seems to be working fine (it's in `~/.cache/octasine/OctaSine.log`), but I can't test it on Windows or Mac.